### PR TITLE
[Added] disqus.com short name and enabled post comments.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,7 +33,7 @@ fb_page_id:
 
 # Disqus post comments
 # (leave blank to disable Disqus)
-disqus_shortname:
+disqus_shortname: rust-leipzig
 
 # Facebook Comments plugin
 # (leave blank to disable Facebook Comments, otherwise set it to true)
@@ -88,6 +88,7 @@ text:
     updated:        'Updated'
     minute_read:    'minute read'
     related_posts:  'Related Posts'
+    comments:       'Comments'
   index:
     coming_soon: 'Coming soon...'
   contact:

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -35,6 +35,7 @@ layout: default
 {% endif %}
 
 {% if site.disqus_shortname %}
+  <h3 class="related-post-title">{{ site.text.post.comments }}</h3>
   <div id="disqus_thread"></div>
   <script type="text/javascript">
     var disqus_shortname  = '{{ site.disqus_shortname }}';


### PR DESCRIPTION
As discussed I created a site on disqus.com: https://rust-leipzig.disqus.com
I set the shortname within the jekyll config to enable the feature for the blog.

It would be nice if one of the maintainer will create an own account on disqus.com to add him/her as admin to the site.